### PR TITLE
change the way pix2tes is called

### DIFF
--- a/qubic/scripts/Calibration/fibtools.py
+++ b/qubic/scripts/Calibration/fibtools.py
@@ -85,16 +85,12 @@ def image_asics(data1=None, data2=None, all1=None):
     img = np.zeros((nrows, ncols)) + np.nan
     for row in range(nrows):
         for col in range(ncols):
-            if data1 is not None:
-                physpix = pix_grid[row, col]
-                if physpix in TES2PIX[0]:
-                    TES = pix2tes(physpix,asic=1)
-                    img[row, col] = data1[TES - 1]
-            if data2 is not None:
-                physpix = pix_grid[row, col]
-                if physpix in TES2PIX[1]:
-                    TES = pix2tes(physpix,asic=2)
-                    img[row, col] = data2[TES - 1]
+            physpix = pix_grid[row, col]
+            TES,asic = pix2tes(physpix)
+            if data1 is not None and asic==1:
+                img[row, col] = data1[TES - 1]
+            if data2 is not None and asic==2:
+                img[row, col] = data2[TES - 1]
     return img
 
 

--- a/qubic/scripts/Calibration/selfcal_lib.py
+++ b/qubic/scripts/Calibration/selfcal_lib.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 
 import glob
 import healpy as hp
@@ -7,7 +7,7 @@ import pandas as pd
 import cv2
 
 from qubicpack import qubicpack as qp
-from qubicpack import pix2tes
+from qubicpack.pix2tes import pix2tes, assign_pix2tes, assign_pix_grid
 from qubicpack.utilities import ASIC_index
 
 import qubic
@@ -399,21 +399,19 @@ class SelfCalibration:
         """
 
         tes_signal = np.zeros(256)
-        pix_grid = pix2tes.assign_pix_grid()
+        pix_grid = assign_pix_grid()
 
-        TES2PIX = pix2tes.assign_pix2tes()
+        TES2PIX = assign_pix2tes()
         for l in range(17):
             for c in range(17):
                 pix = pix_grid[l, c]
                 if pix != 0.:
-                    if pix in TES2PIX[ASIC_index(1), :]:
-                        tes = pix2tes.pix2tes(pix, 1)
+                    tes,asic = pix2tes(pix)
+                    if asic==2: # ASIC2 goes from 1-128
                         tes_signal[tes - 1] = image_fp[l, c]
-
-                    else:
-                        tes = pix2tes.pix2tes(pix, 2)
+                    else: # ASIC1 goes from 129-256
                         tes_signal[tes - 1 + 128] = image_fp[l, c]
-
+                        
         return tes_signal
 
     @staticmethod


### PR DESCRIPTION
I've changed the way pix2tes works because you don't have to give the ASIC number.  I corrected two scripts which use pix2tes.  They are selfcal_lib.py and fibtools.py